### PR TITLE
Remove named release from version number.

### DIFF
--- a/social_auth_backend_bigcommerce/__init__.py
+++ b/social_auth_backend_bigcommerce/__init__.py
@@ -2,4 +2,4 @@
 BigCommerce backend for Social Auth.
 """
 
-__version__ = '0.1.0-maple.1'
+__version__ = '0.1.0'


### PR DESCRIPTION
No need to have named release (e.g. "-maple.1") in the python package version name.