### PR TITLE
fix(third-party-auth): Need to account for additional required demographic fields for BigCommerce provider.

### DIFF
--- a/social_auth_backend_bigcommerce/backend.py
+++ b/social_auth_backend_bigcommerce/backend.py
@@ -245,6 +245,8 @@ class BigCommerceCustomerBaseAuth(EmailAuth):  # pylint: disable=abstract-method
         self.data['email'] = bc_customer_metadata.get('email')
         self.data['first_name'] = bc_customer_metadata.get('first_name')
         self.data['last_name'] = bc_customer_metadata.get('last_name')
+        self.data['postal_code'] = bc_customer_metadata.get('postal_code')
+        self.data['country_code'] = bc_customer_metadata.get('country_code')
 
         if self.ID_KEY not in self.data:
             raise AuthMissingParameter(self, self.ID_KEY)
@@ -264,6 +266,9 @@ class BigCommerceCustomerBaseAuth(EmailAuth):  # pylint: disable=abstract-method
         )
         if email and not username:
             username = email.split('@', 1)[0]
+        postal_code = response.get('postal_code')
+        country_code = response.get('country_code')
+        
         return {
             'store_hash': store_hash,
             'id': id,
@@ -272,7 +277,16 @@ class BigCommerceCustomerBaseAuth(EmailAuth):  # pylint: disable=abstract-method
             'fullname': fullname,
             'first_name': first_name,
             'last_name': last_name,
-            'country': 'US'
+            'level_of_education': 'prefer-not-to-say',
+            'enrolled_in_school': 'prefer-not-to-say',
+            'enrolled_in_school_type': 'prefer-not-to-say',
+            'year_of_birth': None,
+            'gender': 'prefer-not-to-say',
+            'ethnicity': 'prefer-not-to-say',
+            'local_community_living': 'prefer-not-to-say',
+            'employment_status': 'prefer-not-to-say',
+            'zipcode': postal_code,
+            'country': country_code
         }
 
     def extra_data(self, user, uid, response, details=None, *args, **kwargs):


### PR DESCRIPTION
This relates to platform change here.
https://github.com/CUCWD/edx-platform/pull/179

When creating an account with third-party auth provider BigCommerce on EducateWorkforce it appears that new required fields set by platform setting REGISTRATION_EXTRA_FIELDS were causing the automatic account creation using `Skip registration form` set to `True` to fail.

This fix makes sure that all required fields get a default value of `prefer-not-to-say` or we override the `required` field to `optional` using third-party provider  `Other settings` below to ignore the required field and provide a null value. In this case the `year_of_birth` field didn't have a `prefer-not-to-say` value by default since it was an Integer field.

`Third-Party Auth Provider > Option settings`
```
{
    "REGISTRATION_EXTRA_FIELDS": {
        "year_of_birth": "optional"
    },
    ...
}
```

We could have optionally updated the BigCommerce registration account creation fields to account for these `required` fields that we are defaulting to `prefer-not-to-say` value, however, we'd have to get with the BigCommerce storefront administrator to make this change occur. For now we're going to keep this hidden as a requirement.

BigCommerce Article – Adding and Editing Fields in the Account Signup Form
https://support.bigcommerce.com/s/article/Editing-Form-Fields?language=en_US